### PR TITLE
Feature/pca plot: PCA Module Enhancement: K-means Clustering and Visualization Improvements

### DIFF
--- a/R/DEplotFuns.R
+++ b/R/DEplotFuns.R
@@ -300,83 +300,72 @@ createPCAPlot <- function(pcaResult, colData, pcX, pcY) {
     theme_minimal()
 }
 
-#' @title PCAplot with arrow and cluster
+#' @title PCAplot with distance and cluster labeling
 #' @description PCA plot for RNAseq expression
 #' @param pcaResult pca table
 #' @param colData gene symbol
-#' @param pcX x axis PC dimension
-#' @param pcY y axis PC dimension
+#' @param enableClustering set clustering or not
+#' @param centers centers number (default = 2)
 #' @return PCA plot
 #' @export
-
-createPCAPlot_withArrows <- function(pcaResult, colData, pcX, pcY) {
+createPCAPlot <- function(pcaResult, colData, enableClustering = FALSE, centers = 2) {
+  # 取得 PCA 之後的各樣本分數，並加入樣本名稱
   pcaData <- as.data.frame(pcaResult$x)
   pcaData$Sample <- rownames(pcaData)
-  mergedData <- merge(pcaData, colData, by.x = "Sample", by.y = "mainCode", all.x = TRUE)
+  
+  # 計算 PC1 與 PC2 的解釋變異比例
+  explained <- summary(pcaResult)$importance["Proportion of Variance", ]
+  xlab <- paste0("PC1 (", round(explained["PC1"] * 100, 1), "%)")
+  ylab <- paste0("PC2 (", round(explained["PC2"] * 100, 1), "%)")
+  # 先計算所有數據點的範圍，以便兩種模式使用相同的座標系統
+  x_range <- range(pcaData$PC1)
+  y_range <- range(pcaData$PC2)
+  # 添加一些邊距空間，確保標籤有足夠顯示空間
+  x_padding <- 0.15 * diff(x_range)
+  y_padding <- 0.15 * diff(y_range)
+  x_lim <- c(x_range[1] - x_padding, x_range[2] + x_padding)
+  y_lim <- c(y_range[1] - y_padding, y_range[2] + y_padding)
 
-  centroids <- mergedData %>%
-    group_by(subCode) %>%
-    summarise(
-      cx = mean(.data[[pcX]]),
-      cy = mean(.data[[pcY]]),
-      .groups = "drop"
+  if (enableClustering) {
+    # 使用 PC1 與 PC2 做分群
+    clusterData <- pcaData[, c("PC1", "PC2")]
+    set.seed(123)
+    km.res <- kmeans(clusterData, centers = centers, nstart = 25)
+    
+    plot <- fviz_cluster(km.res,
+                        data = clusterData,
+                        stand = FALSE,
+                        ellipse.type = "norm",    # 常態分佈橢圓
+                        star.plot = TRUE,         # 畫出從中心到點的連線
+                        repel = TRUE,             # 避免標籤重疊
+                        geom = "point",           # 使用點標示
+                        show.clust.cent = TRUE,
+                        labelsize = 4,
+                        ggtheme = theme_minimal()
     )
-
-  mergedData <- mergedData %>%
-    left_join(centroids, by = "subCode") %>%
-    mutate(
-      distToCenter = sqrt((.data[[pcX]] - cx)^2 + (.data[[pcY]] - cy)^2),
-      dx = .data[[pcX]] - cx,
-      dy = .data[[pcY]] - cy,
-      arrowRatio = 0.9,
-      xend = cx + dx * arrowRatio,
-      yend = cy + dy * arrowRatio
-    )
-
-  circleData <- mergedData %>%
-    group_by(subCode) %>%
-    summarise(
-      radius = max(distToCenter),
-      cx = first(cx), cy = first(cy),
-      .groups = "drop"
-    )
-
-  var_percent <- round(100 * pcaResult$sdev^2 / sum(pcaResult$sdev^2), 1)
-  names(var_percent) <- colnames(pcaResult$x)
-  xlab <- paste0(pcX, " (", var_percent[pcX], "%)")
-  ylab <- paste0(pcY, " (", var_percent[pcY], "%)")
-
-  ggplot(mergedData, aes(x = !!sym(pcX), y = !!sym(pcY), color = subCode)) +
-    # Group background circles
-    geom_circle(data = circleData,
-                aes(x0 = cx, y0 = cy, r = radius, fill = subCode),
-                inherit.aes = FALSE,
-                color = NA, alpha = 0.15) +
-
-    # Sample → center arrows
-    geom_segment(
-      aes(x = cx, y = cy, xend = xend, yend = yend),
-      linetype = "dashed",
-      arrow = arrow(length = unit(0.3, "cm"), type = "closed"),
-      size = 1.2
-    ) +
-
-    # Sample points with border
-    geom_point(shape = 21, size = 4, stroke = 1, fill = "white") +
-
-    # Labels (smart position)
-    ggrepel::geom_text_repel(aes(label = Sample),
-                             size = 3.5,
-                             max.overlaps = 50,
-                             box.padding = 0.3) +
-
-    # Group center
-    geom_point(data = centroids,
-               aes(x = cx, y = cy),
-               inherit.aes = FALSE,
-               shape = 4, size = 6, stroke = 2, color = "black") +
-
-    labs(title = "PCA: Group Structure with Arrows",
-         x = xlab, y = ylab, color = "Group", fill = "Group") +
-    theme_minimal(base_size = 14)
+    
+    # 確保fviz_cluster的圖使用相同的坐標軸範圍
+    plot <- plot + coord_cartesian(xlim = x_lim, ylim = y_lim) + labs(title = "PCA Plot (Original Groups)",
+          x = xlab,
+          y = ylab,
+          color = "Group")
+    
+  } else {
+    # 將 PCA 結果與 colData 合併，以原始分組上色
+    mergedData <- merge(pcaData, colData, by.x = "Sample", by.y = "mainCode", all.x = TRUE)
+    
+    plot <- ggplot(mergedData, aes(x = PC1, y = PC2, label = Sample, color = subCode)) +
+      # 使用相同的坐標軸範圍
+      coord_cartesian(xlim = x_lim, ylim = y_lim) +
+      geom_point(size = 3) +
+      # 使用ggrepel代替直接的geom_text，避免標籤重疊
+      ggrepel::geom_text_repel(size = 4, max.overlaps = 200) +
+      labs(title = "PCA Plot (Original Groups)",
+          x = xlab,
+          y = ylab,
+          color = "Group") +
+      theme_minimal()
+  }
+  
+  return(plot)
 }

--- a/R/RNAseqShinyApp.R
+++ b/R/RNAseqShinyApp.R
@@ -107,7 +107,7 @@ RNAseqShinyAppSpark <- function(master = "sc://172.18.0.1:15002", method = "spar
         )
       ),
       tabPanel(
-        title = "PCA",
+        title = "Principal Component Analysis",
         mainPanel(
           width = 12,
           pcaModuleUI("pca1")

--- a/R/RNAseqShinyApp.R
+++ b/R/RNAseqShinyApp.R
@@ -109,6 +109,7 @@ RNAseqShinyAppSpark <- function(master = "sc://172.18.0.1:15002", method = "spar
       tabPanel(
         title = "PCA",
         mainPanel(
+          width = 12,
           pcaModuleUI("pca1")
         )
       ),

--- a/R/shinyModule.R
+++ b/R/shinyModule.R
@@ -475,7 +475,7 @@ mod_geneSelector_server <- function(id, deg_table, geneList) {
 
 pcaModuleUI <- function(id) {
   ns <- NS(id)
-  tabPanel("PCA",
+  tabPanel("Principal Component Analysis",
            sidebarLayout(
              sidebarPanel(
                checkboxInput(ns("toggleClustering"), "Enable Clustering", value = FALSE)

--- a/R/shinyModule.R
+++ b/R/shinyModule.R
@@ -498,31 +498,23 @@ pcaModuleUI <- function(id) {
 
 pcaModuleServer <- function(id, normCount, colData) {
   moduleServer(id, function(input, output, session) {
-    # Compute PCA once and store the result
-    
     pcaResult <- reactive({
       df <- normCount
-      rownames(df) <- df$"GeneSymbol"
-      df <- df[,-1]
-      colnames(df) <- sub("\\.", "-", colnames(df))
+      rownames(df) <- df$GeneSymbol
+      df <- df[, -1]
       prcomp(t(df), scale. = TRUE)
     })
-    pcs <- reactive({
-      colnames(as.data.frame(pcaResult()$x))
-    })
 
-    # Update selectInput choices with available principal components
-    observeEvent(pcs(), {
-      updateSelectInput(session, "pcX", choices = pcs(), selected = pcs()[1])
-      updateSelectInput(session, "pcY", choices = pcs(), selected = pcs()[2])
+    observeEvent(pcaResult(), {
+      pcs <- colnames(pcaResult()$x)
+      updateSelectInput(session, "pcX", choices = pcs, selected = pcs[1])
+      updateSelectInput(session, "pcY", choices = pcs, selected = pcs[2])
     }, once = TRUE)
-    # Render the PCA plot using the precomputed PCA result
+
     output$pcaPlot <- renderPlot({
       req(input$pcX, input$pcY)
-      createPCAPlot(pcaResult(), colData, input$pcX, input$pcY)
-     
+      createPCAPlot_withArrows(pcaResult(), colData, input$pcX, input$pcY)
     })
-    outputOptions(output, "pcaPlot", suspendWhenHidden = FALSE)
   })
 }
 

--- a/R/shinyModule.R
+++ b/R/shinyModule.R
@@ -475,17 +475,16 @@ mod_geneSelector_server <- function(id, deg_table, geneList) {
 
 pcaModuleUI <- function(id) {
   ns <- NS(id)
-  tabPanel("PCA",
-    sidebarLayout(
-      sidebarPanel(
-        selectInput(ns("pcX"), "Select X-axis:", choices = NULL),
-        selectInput(ns("pcY"), "Select Y-axis:", choices = NULL)
-      ),
-      mainPanel(
-        plotOutput(ns("pcaPlot"))
-      )
-    )
-  )
+  tabPanel("PCA Arrows",
+           sidebarLayout(
+             sidebarPanel(
+               selectInput(ns("pcX"), "X-axis PC", choices = NULL),
+               selectInput(ns("pcY"), "Y-axis PC", choices = NULL)
+             ),
+             mainPanel(
+               plotOutput(ns("pcaPlot"))
+             )
+           ))
 }
 
 #' @title PCA plot Server

--- a/man/createPCAPlot.Rd
+++ b/man/createPCAPlot.Rd
@@ -4,12 +4,18 @@
 \alias{createPCAPlot}
 \title{PCAplot}
 \usage{
-createPCAPlot(pcaResult, colData, pcX, pcY)
+createPCAPlot(pcaResult, colData, enableClustering = FALSE, centers = 2)
+
+createPCAPlot(pcaResult, colData, enableClustering = FALSE, centers = 2)
 }
 \arguments{
 \item{pcaResult}{pca table}
 
 \item{colData}{gene symbol}
+
+\item{enableClustering}{set clustering or not}
+
+\item{centers}{centers number (default = 2)}
 
 \item{pcX}{x axis PC dimension}
 
@@ -17,7 +23,11 @@ createPCAPlot(pcaResult, colData, pcX, pcY)
 }
 \value{
 PCA plot
+
+PCA plot
 }
 \description{
+PCA plot for RNAseq expression
+
 PCA plot for RNAseq expression
 }


### PR DESCRIPTION
# PCA Module Enhancement: K-means Clustering and Visualization Improvements

## Overview
This PR enhances the PCA module with new clustering functionality and improved visualization options. Users can now toggle between viewing original sample groupings and k-means clustering results directly in the UI.

## Key Features

### 1. K-means Clustering on PCA Results
- Implemented k-means clustering on PC1 and PC2 dimensions
- Added a toggle switch in the UI to enable/disable clustering view
- Set default clustering to 2 centers with multiple starts for stability

### 2. Visualization Improvements
- Added explanatory axis labels showing variance explained by each principal component
- Ensured consistent coordinate systems between visualization modes for easier comparison
- Implemented smart axis padding to accommodate all data points and labels
- Added cluster ellipses (normal distribution) to visually separate groups
- Included "star plot" lines connecting points to their cluster centers

### 3. UI Enhancements
- Simple checkbox toggle to switch between original grouping and clustering views
- Maintained consistent plot dimensions when switching between modes
- Improved label placement with ggrepel to prevent overlapping text
- Added informative titles and legends for better data interpretation

### 4. Implementation Details
- Used factoextra::fviz_cluster for efficient cluster visualization
- Carefully aligned coordinate systems between both visualization modes
- Increased max.overlaps parameter to ensure all sample labels are visible
- Added proper titling and color legends for both visualization modes